### PR TITLE
feat(thoughts): add thoughts/blog section to homepage

### DIFF
--- a/apps/homepage/app/components/ThoughtsHeader.tsx
+++ b/apps/homepage/app/components/ThoughtsHeader.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+export default function ThoughtsHeader() {
+  return (
+    <header className="thoughts-header" aria-label="Thoughts navigation">
+      <div className="thoughts-header-inner">
+        <Link
+          href="/"
+          className="thoughts-header-back"
+          aria-label="Back to home"
+        >
+          <span className="thoughts-header-back-arrow" aria-hidden="true">
+            ←
+          </span>
+          <span>Henri Maronen</span>
+        </Link>
+        <Link href="/thoughts" className="thoughts-header-label">
+          Thoughts
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/apps/homepage/app/globals.css
+++ b/apps/homepage/app/globals.css
@@ -2179,3 +2179,449 @@ select {
     width: min(100%, 24rem, calc(100dvh - 10.5rem));
   }
 }
+
+/* ── Thoughts / Blog ─────────────────────────────────────── */
+
+/* Page shell — shared by listing and article */
+.thoughts-page {
+  min-height: 100dvh;
+  padding-top: 5rem;
+}
+
+/* ── Thoughts Header ── */
+
+.thoughts-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  padding: 0 clamp(1.5rem, 4vw, 3.5rem);
+  height: 4rem;
+  display: flex;
+  align-items: center;
+  background: rgba(250, 247, 242, 0.88);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(155, 106, 62, 0.1);
+}
+
+.thoughts-header-inner {
+  width: 100%;
+  max-width: var(--shell);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.thoughts-header-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-nav);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-nav);
+  text-transform: uppercase;
+  color: var(--charcoal-mid);
+  transition: color var(--motion-fast);
+}
+
+.thoughts-header-back:hover {
+  color: var(--accent);
+}
+
+.thoughts-header-back-arrow {
+  display: inline-block;
+  transition: transform var(--motion-fast);
+}
+
+.thoughts-header-back:hover .thoughts-header-back-arrow {
+  transform: translateX(-3px);
+}
+
+.thoughts-header-label {
+  font-family: var(--font-family-display);
+  font-size: var(--font-size-nav);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+/* ── Listing page ── */
+
+.thoughts-shell {
+  width: min(calc(100% - 4rem), 760px);
+  margin: 0 auto;
+  padding: clamp(2rem, 4vw, 3.5rem) 0 clamp(3rem, 5vw, 5rem);
+}
+
+/* Masthead */
+.thoughts-hero {
+  padding-bottom: clamp(1.5rem, 3vw, 2.5rem);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.thoughts-hero-eyebrow {
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 1rem;
+}
+
+.thoughts-hero-title {
+  font-family: var(--font-family-display);
+  font-size: clamp(2.8rem, 7vw, 5rem);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  letter-spacing: var(--tracking-display);
+  text-transform: uppercase;
+  color: var(--charcoal);
+  margin: 0 0 0.75rem;
+}
+
+.thoughts-hero-sub {
+  font-size: var(--font-size-body-large);
+  line-height: var(--line-height-body);
+  color: var(--muted);
+  margin: 0;
+  max-width: 44ch;
+}
+
+/* Entries list */
+.thoughts-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+@keyframes thoughts-entry-rise {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.thoughts-entry {
+  padding: clamp(1.75rem, 3vw, 2.5rem) 0;
+  border-bottom: 1px solid var(--border);
+  opacity: 0;
+  animation: thoughts-entry-rise 0.6s var(--motion-reveal-ease)
+    calc(var(--i, 0) * 0.1s) forwards;
+}
+
+.thoughts-entry-link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.thoughts-entry-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.9rem;
+}
+
+.thoughts-entry-date {
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.thoughts-entry-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.thoughts-entry .button-conic-wrapper .button {
+  padding: 0.22rem 0.26rem 0.22rem 0.6rem;
+  font-size: 0.65rem;
+  min-width: auto;
+}
+
+.thoughts-entry .button-conic-wrapper .button-orb {
+  width: 1.4rem;
+  height: 1.4rem;
+}
+
+.thoughts-entry .button-conic-wrapper .button-orb svg {
+  width: 0.65rem;
+  height: 0.65rem;
+}
+
+.thoughts-tag {
+  display: inline-block;
+  padding: 0.2em 0.65em;
+  font-family: var(--font-family-body);
+  font-size: 0.68rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cognac);
+  background: rgba(155, 106, 62, 0.08);
+  border: 1px solid rgba(155, 106, 62, 0.2);
+  border-radius: var(--radius-pill);
+}
+
+.thoughts-entry-title {
+  font-family: var(--font-family-display);
+  font-size: clamp(1.3rem, 2.5vw, 1.9rem);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-heading);
+  letter-spacing: var(--tracking-display);
+  text-transform: uppercase;
+  color: var(--charcoal);
+  margin: 0 0 0.75rem;
+  transition: color var(--motion-fast);
+  max-width: none;
+}
+
+.thoughts-entry-link:hover .thoughts-entry-title {
+  color: var(--accent);
+}
+
+.thoughts-entry-excerpt {
+  font-size: var(--font-size-body);
+  line-height: 1.65;
+  color: var(--charcoal-mid);
+  margin: 0 0 1rem;
+  max-width: 60ch;
+}
+
+.thoughts-empty {
+  font-size: var(--font-size-body-large);
+  color: var(--muted);
+  padding: 3rem 0;
+}
+
+/* ── Article page ── */
+
+.thoughts-article-shell {
+  width: min(calc(100% - 4rem), 58ch);
+  margin: 0 auto;
+  padding: clamp(3rem, 5vw, 4.5rem) 0 clamp(5rem, 8vw, 7rem);
+}
+
+.thoughts-article-header {
+  padding-bottom: clamp(2rem, 3.5vw, 3rem);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.thoughts-article-date {
+  display: block;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 1rem;
+}
+
+.thoughts-article-title {
+  font-family: var(--font-family-display);
+  font-size: clamp(2.4rem, 6vw, 4.2rem);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  letter-spacing: var(--tracking-display);
+  text-transform: uppercase;
+  color: var(--charcoal);
+  margin: 0 0 1.5rem;
+}
+
+.thoughts-article-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.25rem;
+}
+
+/* Article prose body */
+.thoughts-article-body {
+  font-size: var(--font-size-body-large);
+  line-height: 1.7;
+  color: var(--charcoal-mid);
+}
+
+.thoughts-article-body p {
+  margin: 0 0 1em;
+}
+
+.thoughts-article-body p:last-child {
+  margin-bottom: 0;
+}
+
+.thoughts-article-body h2 {
+  font-family: var(--font-family-display);
+  font-size: clamp(1.3rem, 2.5vw, 1.75rem);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-display);
+  text-transform: uppercase;
+  color: var(--charcoal);
+  margin: 2.5em 0 0.8em;
+  padding-bottom: 0.4em;
+  border-bottom: 1px solid var(--border);
+}
+
+.thoughts-article-body h3 {
+  font-family: var(--font-family-display);
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  color: var(--charcoal);
+  margin: 2em 0 0.65em;
+}
+
+.thoughts-article-body strong {
+  font-weight: var(--font-weight-semibold);
+  color: var(--charcoal);
+}
+
+.thoughts-article-body em {
+  color: var(--charcoal);
+}
+
+.thoughts-article-body a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: opacity var(--motion-fast);
+}
+
+.thoughts-article-body a:hover {
+  opacity: 0.75;
+}
+
+.thoughts-article-body blockquote {
+  margin: 2em 0;
+  padding: 0.1em 0 0.1em 1.5em;
+  border-left: 3px solid var(--accent);
+  color: var(--charcoal-mid);
+  font-style: italic;
+}
+
+.thoughts-article-body blockquote p {
+  margin: 0.6em 0;
+}
+
+.thoughts-article-body ul,
+.thoughts-article-body ol {
+  padding-left: 1.5em;
+  margin: 0 0 1.6em;
+}
+
+.thoughts-article-body li {
+  margin-bottom: 0.4em;
+}
+
+.thoughts-article-body code {
+  font-size: 0.88em;
+  padding: 0.15em 0.4em;
+  background: rgba(155, 106, 62, 0.1);
+  border-radius: var(--radius-sm);
+  color: var(--cognac);
+  font-family:
+    ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
+}
+
+.thoughts-article-body pre {
+  padding: 1.25em 1.5em;
+  background: rgba(44, 44, 42, 0.04);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  margin: 0 0 1.6em;
+}
+
+.thoughts-article-body pre code {
+  background: none;
+  padding: 0;
+  color: var(--charcoal);
+  font-size: 0.88em;
+}
+
+.thoughts-article-body hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2.5em 0;
+}
+
+/* Article footer */
+.thoughts-article-footer {
+  margin-top: clamp(3rem, 5vw, 4rem);
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+}
+
+.thoughts-article-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--charcoal-mid);
+  text-decoration: none;
+  transition: color var(--motion-fast);
+}
+
+.thoughts-article-back:hover {
+  color: var(--accent);
+}
+
+.thoughts-article-back span {
+  display: inline-block;
+  transition: transform var(--motion-fast);
+}
+
+.thoughts-article-back:hover span {
+  transform: translateX(-3px);
+}
+
+/* ── Responsive: thoughts ── */
+
+@media (max-width: 600px) {
+  .thoughts-shell {
+    width: min(calc(100% - 2.5rem), var(--shell));
+  }
+
+  .thoughts-article-shell {
+    width: min(calc(100% - 2.5rem), 68ch);
+  }
+
+  .thoughts-hero-title {
+    font-size: clamp(2.2rem, 10vw, 3.5rem);
+  }
+
+  .thoughts-entry-title {
+    font-size: clamp(1.2rem, 5.5vw, 1.6rem);
+    max-width: none;
+  }
+
+  .thoughts-article-title {
+    font-size: clamp(2rem, 9vw, 3rem);
+  }
+}

--- a/apps/homepage/app/homepage-data.ts
+++ b/apps/homepage/app/homepage-data.ts
@@ -62,6 +62,7 @@ export const navItems: NavItem[] = [
   { label: "Experience", href: "#work" },
   { label: "Projects", href: "#projects" },
   { label: "Connect", href: "#connect" },
+  { label: "Thoughts", href: "/thoughts" },
 ];
 
 export const socialLinks: SocialLink[] = [

--- a/apps/homepage/app/lib/thoughts.ts
+++ b/apps/homepage/app/lib/thoughts.ts
@@ -1,0 +1,91 @@
+import fs from "fs";
+import { marked } from "marked";
+import matter from "gray-matter";
+import path from "path";
+import { notFound } from "next/navigation";
+
+export interface ThoughtMeta {
+  slug: string;
+  title: string;
+  date: string;
+  formattedDate: string;
+  tags: string[];
+  excerpt: string;
+}
+
+export interface Thought extends ThoughtMeta {
+  htmlContent: string;
+}
+
+const THOUGHTS_DIR = path.join(process.cwd(), "content/thoughts");
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/[#*`_()\]>]/g, "")
+    .replace(/\[/g, "")
+    .trim();
+}
+
+function makeExcerpt(content: string): string {
+  const stripped = stripMarkdown(content);
+  return stripped.length > 180 ? stripped.substring(0, 180) + "…" : stripped;
+}
+
+export function getAllThoughts(): ThoughtMeta[] {
+  const files = fs.readdirSync(THOUGHTS_DIR).filter((f) => f.endsWith(".md"));
+
+  const thoughts = files.map((filename): ThoughtMeta => {
+    const slug = filename.replace(/\.md$/, "");
+    const raw = fs.readFileSync(path.join(THOUGHTS_DIR, filename), "utf-8");
+    const { data, content } = matter(raw);
+
+    return {
+      slug,
+      title: data.title as string,
+      date: data.date as string,
+      formattedDate: formatDate(data.date as string),
+      tags: (data.tags as string[]) ?? [],
+      excerpt: makeExcerpt(content),
+    };
+  });
+
+  return thoughts.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+}
+
+export function getThought(slug: string): Thought {
+  const filepath = path.join(THOUGHTS_DIR, `${slug}.md`);
+
+  if (!fs.existsSync(filepath)) {
+    notFound();
+  }
+
+  const raw = fs.readFileSync(filepath, "utf-8");
+  const { data, content } = matter(raw);
+
+  const htmlContent = marked.parse(content, { async: false }) as string;
+
+  return {
+    slug,
+    title: data.title as string,
+    date: data.date as string,
+    formattedDate: formatDate(data.date as string),
+    tags: (data.tags as string[]) ?? [],
+    excerpt: stripMarkdown(content).substring(0, 180) + "…",
+    htmlContent,
+  };
+}
+
+export function getThoughtSlugs(): { slug: string }[] {
+  const files = fs.readdirSync(THOUGHTS_DIR).filter((f) => f.endsWith(".md"));
+  return files.map((f) => ({ slug: f.replace(/\.md$/, "") }));
+}

--- a/apps/homepage/app/thoughts/[slug]/page.tsx
+++ b/apps/homepage/app/thoughts/[slug]/page.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { getThought, getThoughtSlugs } from "../../lib/thoughts";
+
+export async function generateStaticParams() {
+  return getThoughtSlugs();
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  try {
+    const thought = getThought(slug);
+    return {
+      title: `${thought.title} — Henri Maronen`,
+      description: thought.excerpt,
+    };
+  } catch {
+    return {};
+  }
+}
+
+export default async function ThoughtPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const thought = getThought(slug);
+
+  return (
+    <main className="thoughts-page">
+      <div className="thoughts-article-shell">
+        {/* Article header */}
+        <header className="thoughts-article-header">
+          <time className="thoughts-article-date" dateTime={thought.date}>
+            {thought.formattedDate}
+          </time>
+          <h1 className="thoughts-article-title">{thought.title}</h1>
+          {thought.tags.length > 0 && (
+            <div className="thoughts-article-tags" aria-label="Tags">
+              {thought.tags.map((tag) => (
+                <span key={tag} className="thoughts-tag">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </header>
+
+        {/* Article body */}
+        <article
+          className="thoughts-article-body"
+          dangerouslySetInnerHTML={{ __html: thought.htmlContent }}
+        />
+
+        {/* Footer nav */}
+        <footer className="thoughts-article-footer">
+          <Link href="/thoughts" className="thoughts-article-back">
+            <span aria-hidden="true">←</span>
+            All thoughts
+          </Link>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/apps/homepage/app/thoughts/layout.tsx
+++ b/apps/homepage/app/thoughts/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+import ThoughtsHeader from "../components/ThoughtsHeader";
+
+type ThoughtsLayoutProps = {
+  children: ReactNode;
+};
+
+export default function ThoughtsLayout({ children }: ThoughtsLayoutProps) {
+  return (
+    <>
+      <ThoughtsHeader />
+      {children}
+    </>
+  );
+}

--- a/apps/homepage/app/thoughts/page.tsx
+++ b/apps/homepage/app/thoughts/page.tsx
@@ -1,0 +1,71 @@
+import type { CSSProperties } from "react";
+import Link from "next/link";
+import { getAllThoughts } from "../lib/thoughts";
+
+export const metadata = {
+  title: "Thoughts — Henri Maronen",
+  description:
+    "Writing on development, design, and the tools and ideas that shape how I build.",
+};
+
+export default function ThoughtsPage() {
+  const thoughts = getAllThoughts();
+
+  return (
+    <main className="thoughts-page">
+      <div className="thoughts-shell">
+        {/* Masthead */}
+        <div className="thoughts-hero">
+          <p className="thoughts-hero-eyebrow">Writing</p>
+          <h1 className="thoughts-hero-title">Thoughts</h1>
+          <p className="thoughts-hero-sub">
+            Notes on development, tools, and the slow accumulation of
+            perspective.
+          </p>
+        </div>
+
+        {/* List */}
+        {thoughts.length === 0 ? (
+          <p className="thoughts-empty">Nothing here yet. Check back soon.</p>
+        ) : (
+          <ol className="thoughts-list" role="list">
+            {thoughts.map((thought, index) => (
+              <li
+                key={thought.slug}
+                className="thoughts-entry"
+                style={{ "--i": index } as CSSProperties}
+              >
+                <Link
+                  href={`/thoughts/${thought.slug}`}
+                  className="thoughts-entry-link"
+                >
+                  <h2 className="thoughts-entry-title">{thought.title}</h2>
+                  {thought.tags.length > 0 && (
+                    <div className="thoughts-entry-tags" aria-label="Tags">
+                      {thought.tags.map((tag) => (
+                        <span key={tag} className="thoughts-tag">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  <span className="button-conic-wrapper">
+                    <span className="button button-charcoal button-sm">
+                      <span className="button-label">Read</span>
+                      <span className="button-orb" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                          <path d="M5 12h12" />
+                          <path d="m12 5 7 7-7 7" />
+                        </svg>
+                      </span>
+                    </span>
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/homepage/content/thoughts/notes-from-reading-the-pragmatic-programmer.md
+++ b/apps/homepage/content/thoughts/notes-from-reading-the-pragmatic-programmer.md
@@ -1,0 +1,99 @@
+---
+title: "Notes from reading The Pragmatic Programmer"
+date: "2026-04-14"
+tags: ["Development", "Books", "Programming"]
+---
+
+I picked up The Pragmatic Programmer expecting another technical book full of obscure terms and convoluted examples. I was quite wrong. Dave Thomas and Andy Hunt write like people who still remember what it's like to not know things, and the result is a book that's less about specific technologies and more about how to think as a developer.
+
+I made a lot of highlights, and these are the ideas that stuck.
+
+## Broken windows
+
+There's a theory from criminology: a building with one broken window will eventually have all its windows broken. Nobody cares about a building that's already damaged, so damage accumulates.
+
+Codebases work the same way. One ugly hack, left in place, signals that hacking is acceptable here. The next developer sees it and thinks "all the rest of this code is like this, I'll just follow along." And they're not wrong to think that the codebase showed them these examples.
+
+The flip side is also true. When you work on something cleanly written and well-structured, you take extra care not to mess it up. The standard is visible, and you rise to meet it.
+
+The practical takeaway is simple: fix the broken windows. If you don't have time for a proper fix, note them down, comment out the offending code, add a "Not Implemented" placeholder, leave a TODO with context. Anything is better than letting the rot signal that nobody cares. Because once that signal takes hold, entropy wins fast. Most software disasters don't start with a big bang, they start a day at a time.
+
+## Tracer bullets vs prototypes
+
+The book makes a distinction here that I think most developers blur.
+
+A prototype exists to answer a question. You build it quick, learn something, throw it away. You might prototype a UI layout in Figma, test a performance hypothesis with a throwaway script, or sketch workflow on Post-it notes. The point is exploration, and the code is disposable.
+
+Tracer bullets are different. The term comes from ammunition that lets shooters see where their rounds are going. In software, you pick a thin slice of functionality, something that touches every layer of your architecture and you build it end-to-end. Real code. Real error handling. Real structure. You just don't build all of it yet.
+
+The value is that you get a working skeleton. Users see something tangible early. Developers have an architectural blueprint to hang code on. And you find integration problems immediately, not three months in when five teams try to snap their pieces together.
+
+Prototypes answer "can this work?"
+
+Tracer bullets answer "how does this all hang together?"
+
+Both are useful, but they serve different purposes, and confusing them leads to either throwing away code you should have kept, or shipping code you should have thrown away.
+
+## Design philosophy: ETC, DRY, orthogonality
+
+The book argues that most design principles are special cases of one idea: Easier to Change. ETC. That's the filter. When you're choosing between two approaches, pick the one that makes the system easier to change later.
+
+DRY (Don't Repeat Yourself) fits under this umbrella, but the book's definition is sharper than most people use it. DRY isn't about avoiding duplicated code, it's about avoiding duplicated knowledge. Two functions can have identical code but represent different things, and that's fine. What's not fine is expressing the same business rule in two places, because when that rule changes you'll update one and forget the other.
+
+Then there's orthogonality. In an orthogonal system, changing one component doesn't force changes in others. You can swap the database without touching the UI. You can redesign the UI without rewriting business logic. The test is straightforward: if you dramatically change the requirements behind one function, how many modules break? In a well-designed system, the answer should be one.
+
+There's a practical diagnostic here too. If your unit tests require importing half the codebase just to run, your modules aren't decoupled. If every bug fix touches a dozen files, your system isn't orthogonal. These are signals worth paying attention to.
+
+The book suggests spending a week deliberately asking yourself: "did the thing I just did make the overall system easier or harder to change?" Do it when you save a file, write a test, fix a bug.
+
+## Knowledge is an expiring asset
+
+Your skills and experience are your most important professional assets. They're also depreciating. What you know today becomes less relevant as the industry goes forward.
+
+The book frames this as a portfolio problem. Same principles apply: invest regularly, diversify, balance risk. Learn an emerging technology before it gets popular, it's risky, like picking an undervalued stock, but the payoff can be enormous. The people who learned Java when it was unknown did very well when it became an industry standard.
+
+The specific advice is blunt. Learn a new language every year. Read a technical book each month. Read nontechnical books too. It doesn't matter if you never use a particular technology on a project or put it on your resume. The process of learning expands your thinking, and bringing ideas from one domain into your current work is where the real value is.
+
+There's a line in the book about isolation being deadly to your career. I think about that one a lot. It's easy to get comfortable with your stack and stop looking around. But the developers who stay effective over decades are the ones who keep learning and applying what they pick up.
+
+## Our job is to help people understand what they want
+
+Requirements don't exist in some clean, discoverable form. They're buried under assumptions and misconceptions. Sometimes they don't exist at all until someone forces the conversation.
+
+That's the developer's job. Not just implementing what's asked for, but being the person who asks "what happens at the edges?" The book puts it well:
+
+> When given something that seems simple, we annoy people by looking for edge cases and asking about them. That's not a bug in how developers think. It's probably our most valuable attribute.
+
+This is also why short iterations matter. You build something small, put it in front of the client, and find out fast if you're headed in the wrong direction. The amount of time lost stays small. And what the client needs a year from now may be completely different from what they think they need today, so locking in requirements early is often a waste.
+
+The book even suggests sitting in on a user's actual work for a week. You'd be surprised how much you learn about how the system will really be used, and how different it is from the spec.
+
+## Stone soup
+
+Here's a technique for getting things built when you can't get buy-in upfront.
+
+Build something small. Make it work. Show people. Let them react. Then say "of course, it would be better if we added…" and pretend it's not important. Wait for them to start asking for the functionality you originally wanted.
+
+People find it easier to join an ongoing success than to approve something that only exists as a proposal. Show them a glimpse of the future and they'll rally around it.
+
+This is startup thinking, but it works inside companies too. The developers I've seen get things done in organizations that resist change are almost always using some version of this pattern, shipping small, showing value, expanding scope once there's momentum.
+
+## Communication is not talking
+
+We've all been in meetings where a developer glazes over the eyes of everyone in the room with a monologue about some arcane technology. That's not communicating. That's just talking.
+
+The book's advice is unglamorous but important. Think about your audience. Are they experts? Do they need hand-holding or just a quick summary? Adjust. Ask "is this a good time to talk about this?" before launching in. And above all, listen. If you don't listen to them, they won't listen to you.
+
+There's a related point about presentation. You can spend hours in the kitchen and ruin it all with poor plating. Same with documentation, proposals, emails. There's no excuse for producing sloppy-looking work when the tools to produce clean output are free and everywhere.
+
+This connects to team dynamics too. The worst teams from the outside are the ones that appear disorganized, meetings with no structure, emails and documents that all look different, inconsistent terminology. The good teams speak with one voice. They might even have a sense of humor.
+
+## Sign your work
+
+The book ends with a challenge: take pride in what you build. Your name on a piece of code should mean something, that it's solid, well written, tested, documented. A professional job, written by a professional.
+
+This isn't about ego. It's about responsibility. When something breaks, don't blame the vendor, the language, management, or your coworkers. If there was a risk the vendor wouldn't deliver, you should have had a backup plan. If your storage melted and took your source code with it because you didn't have backups, that's on you.
+
+The book suggests a useful exercise before you go explain to someone why something went wrong: talk to the rubber duck on your monitor first. Does your excuse sound reasonable, or stupid? If it sounds stupid to a rubber duck, it'll sound worse to your boss. Instead of excuses, provide options. Don't say it can't be done. Explain what can be done.
+
+There's a line near the end about developers being incredibly privileged. Our skills are in demand, we can work from anywhere, we're paid well. The book's challenge is to not waste that. Don't get comfortable and wait for things to happen. Be proactive, invest in your skills, raise your standards, seek out work that makes you better. This industry gives you options that most careers don't. Use them.

--- a/apps/homepage/content/thoughts/the-day-my-phone-shipped-a-design-system.md
+++ b/apps/homepage/content/thoughts/the-day-my-phone-shipped-a-design-system.md
@@ -1,0 +1,31 @@
+---
+title: "The Day My Phone Shipped a Design System"
+date: "2025-07-18"
+tags: ["AI", "Development", "Cursor"]
+---
+
+If you work around code long enough, someone will eventually call you a wizard. It's meant as a compliment. But over time, the magic fades. Reading and writing code becomes routine. You know how the trick works so is no longer magic.
+
+A few days ago, I was sitting on the metro, reading about Cursor's _Background Agents_. I was curious—excited, but skeptical. I opened the agents page, picked one of my side projects, and typed:
+
+> Project is missing centralized design-system, create which for the start includes tokens for fonts, colors, spacings, and breakpoints.
+
+Without hesitation, the agent got to work.
+
+I put the phone back in my pocket, jumped off the metro, and headed for the escalators.
+
+Halfway up, I pulled out my phone again to see what the agent had done.
+
+In that short time, the agent had:
+
+- Written hundreds of lines of design system code.
+- Summarized the work in a clear message.
+- Packaged it all into a ready-to-merge pull request.
+
+I skimmed the code, opened a pull request, and merged it into development branch.
+
+**Done.**
+
+A full design system. Prompted from a phone. On a moving train.
+
+Turns out, even a wizard can be fooled.

--- a/apps/homepage/package.json
+++ b/apps/homepage/package.json
@@ -14,6 +14,8 @@
     "check-all": "pnpm run typecheck && pnpm run lint && pnpm run format:check"
   },
   "dependencies": {
+    "gray-matter": "^4.0.3",
+    "marked": "^16.1.0",
     "next": "^16.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
 
   apps/homepage:
     dependencies:
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      marked:
+        specifier: ^16.1.0
+        version: 16.1.0
       next:
         specifier: ^16.0.1
         version: 16.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
- Add /thoughts listing page and /thoughts/[slug] article pages
- Server-side markdown loading via fs + gray-matter + marked
- Editorial design: ruled list, Oswald headings, 58ch reading column
- ThoughtsHeader component with back-to-home nav
- Migrate existing posts from legacy homepage
- Add Thoughts nav link to homepage header
